### PR TITLE
Removed MonoMod Requirements

### DIFF
--- a/DiminishingReturns/DiminishingReturns.csproj
+++ b/DiminishingReturns/DiminishingReturns.csproj
@@ -35,10 +35,6 @@
         <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" IncludeAssets="compile" />
     </ItemGroup>
 
-    <ItemGroup>
-        <Reference Include="MMHOOK_Assembly-CSharp"><HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\BepInEx\plugins\MMHOOK\MMHOOK_Assembly-CSharp.dll</HintPath></Reference>
-    </ItemGroup> 
-
     <!-- https://github.com/EvaisaDev/UnityNetcodePatcher#usage-as-a-post-build-event -->
     <!-- Syntax to use the tool installed globally -->
     <!-- Allows to patch elements like networked behaviours, RPCs, etc. -->

--- a/DiminishingReturns/Plugin.cs
+++ b/DiminishingReturns/Plugin.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using BepInEx;
 using BepInEx.Logging;
-using JackEhttack.netcode;
+using HarmonyLib;
 using JackEhttack.patch;
 using JackEhttack.service;
 using UnityEngine;
@@ -53,9 +53,9 @@ public class Plugin : BaseUnityPlugin
         NetcodePatcher();
         
         Log.LogInfo($"Applying patches...");
-        ScrapModifierPatch.ApplyPatches();
-        TerminalPatch.ApplyPatches();
-        NetworkObjectManager.ApplyPatches();
+        Harmony.CreateAndPatchAll(typeof(ScrapModifierPatches));
+        Harmony.CreateAndPatchAll(typeof(TerminalPatches));
+        Harmony.CreateAndPatchAll(typeof(NetworkObjectManager));
         Log.LogInfo($"Applied all patches!");
         
     }

--- a/DiminishingReturns/netcode/NetworkHandler.cs
+++ b/DiminishingReturns/netcode/NetworkHandler.cs
@@ -27,7 +27,7 @@ public class NetworkHandler : NetworkBehaviour
     [ClientRpc]
     public void DiscountUpdateClientRpc(float discount)
     {
-        TerminalPatch.UpdatePrices(discount);
+        TerminalPatches.UpdatePrices(discount);
     }
 
 }

--- a/Release/manifest.json
+++ b/Release/manifest.json
@@ -4,7 +4,6 @@
 	"description": "Adds Diminishing Returns to repeated visits to the same planet.",
 	"website_url": "https://github.com/JackEhttack/DiminishingReturns",
 	"dependencies": [
-		"BepInEx-BepInExPack-5.4.2100",
-		"Evaisa-HookGenPatcher-0.0.5"
+		"BepInEx-BepInExPack-5.4.2100"
 	]
 }


### PR DESCRIPTION
MonoMod is no longer required to run DiminishingReturns.

ScrapPatch now runs as late as possible to ensure compatibility with other mods that modify scrap rates.